### PR TITLE
fix: httpbin: switch upstream to multiarch image

### DIFF
--- a/images/httpbin/Dockerfile
+++ b/images/httpbin/Dockerfile
@@ -1,8 +1,10 @@
-FROM kennethreitz/httpbin:latest
+FROM kong/httpbin:latest
+USER root
 
 # Modified from upstream
-COPY third_party/ /usr/local/lib/python3.6/dist-packages/httpbin
+COPY third_party/ /httpbin/httpbin
 
 # Add /files endpoints
-ADD store.py /usr/local/lib/python3.6/dist-packages/httpbin
-RUN echo 'from .store import *' >> /usr/local/lib/python3.6/dist-packages/httpbin/__init__.py
+ADD store.py /httpbin/httpbin
+RUN echo 'from .store import *' >> /httpbin/httpbin/__init__.py
+USER 1001


### PR DESCRIPTION
This changes the upstream image we built on to one that is actually available as arm64. Does minor adjustments because the installation path of httpbin in the image is different.